### PR TITLE
Optionally upload coverage report

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: './'
         type: string
+      upload_coverage:
+        description: 'Whether to upload code coverage reports to Codecov'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   lint:
@@ -53,3 +58,10 @@ jobs:
         run: |
           cd ${{ inputs.package_dir }}
           bun test
+
+      - name: Upload Coverage
+        if: inputs.upload_coverage == true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.ORG_CODECOV_TOKEN }}
+          slug: ${{ github.repository }}


### PR DESCRIPTION
This change allows for uploading code coverage reports to [Codecov](https://about.codecov.io), which can visualize the reports and show a readme badge with the coverage number.