### PR TITLE
Added Codecov token as secret

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,10 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      ORG_CODECOV_TOKEN:
+        description: 'Token for uploading code coverage reports to Codecov'
+        required: false
 
 jobs:
   lint:


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/actions/pull/1 and ensures that Codecov has access to its respective token.