### PR TITLE
Fixed repository URL

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -42,7 +42,7 @@ jobs:
         run: bun run build
         
       - name: Bump Package
-        uses: ronin-co/github-actions/.github/actions/bump-version@main
+        uses: ronin-co/actions/.github/actions/bump-version@main
         with:
           package_dir: './'
 


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/actions/pull/3!