### PR TITLE
Configure Bun version in `validate` workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,19 +3,24 @@ name: Validate
 on:
   workflow_call:
     inputs:
-      package_dir:
-        description: 'Directory of the package to validate'
+      bun_version:
+        description: "The version of Bun to use"
         required: false
-        default: './'
+        default: "1.1.34"
+        type: string
+      package_dir:
+        description: "Directory of the package to validate"
+        required: false
+        default: "./"
         type: string
       upload_coverage:
-        description: 'Whether to upload code coverage reports to Codecov'
+        description: "Whether to upload code coverage reports to Codecov"
         required: false
         default: false
         type: boolean
     secrets:
       ORG_CODECOV_TOKEN:
-        description: 'Token for uploading code coverage reports to Codecov'
+        description: "Token for uploading code coverage reports to Codecov"
         required: false
 
 jobs:
@@ -29,7 +34,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.34
+          bun-version: ${{ inputs.bun_version }}
 
       - name: Install Dependencies
         run: |
@@ -51,7 +56,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.34
+          bun-version: ${{ inputs.bun_version }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,23 +4,23 @@ on:
   workflow_call:
     inputs:
       bun_version:
-        description: "The version of Bun to use"
+        description: 'The version of Bun to use'
         required: false
-        default: "1.1.34"
+        default: '1.1.34'
         type: string
       package_dir:
-        description: "Directory of the package to validate"
+        description: 'Directory of the package to validate'
         required: false
-        default: "./"
+        default: './'
         type: string
       upload_coverage:
-        description: "Whether to upload code coverage reports to Codecov"
+        description: 'Whether to upload code coverage reports to Codecov'
         required: false
         default: false
         type: boolean
     secrets:
       ORG_CODECOV_TOKEN:
-        description: "Token for uploading code coverage reports to Codecov"
+        description: 'Token for uploading code coverage reports to Codecov'
         required: false
 
 jobs:


### PR DESCRIPTION
This PR makes a small tweak to the `validate` workflow to allow you to provide a custom Bun version as an input.
By default it will stay as `1.1.34` so nothing else currently breaks.