### PR TITLE
Run correct test script

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test
         run: |
           cd ${{ inputs.package_dir }}
-          bun test
+          bun run test
 
       - name: Upload Coverage
         if: inputs.upload_coverage == true


### PR DESCRIPTION
Our GitHub Action workflows should run `bun run test`, not `bun test` in a repo.