### PR TITLE
Allow for running build before tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      build:
+        description: 'Whether to build before testing'
+        required: false
+        default: false
+        type: boolean
     secrets:
       ORG_CODECOV_TOKEN:
         description: 'Token for uploading code coverage reports to Codecov'
@@ -62,6 +67,12 @@ jobs:
         run: |
           cd ${{ inputs.package_dir }}
           bun install
+
+      - name: Build
+        if: inputs.build == true
+        run: |
+          cd ${{ inputs.package_dir }}
+          bun run build
 
       - name: Test
         run: |


### PR DESCRIPTION
To allow for running a build before testing, only in CI, we would like to add this flag.

It's also possible to do this using a `package.json` script, of course, but then the build always repeats whenever the respective action happens. For an ideal development experience locally, we want the build to remain explicit, meaning if someone wants to trigger a build, they can do so, but we shouldn't slow people down every time.