### PR TITLE
Improved support for workspaces

### DIFF
--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -109,5 +109,4 @@ jobs:
       - name: Publish npm Packages
         if: inputs.workspaces == true
         run: |
-          cd ${{ inputs.package_dir }}
           npm publish --workspaces=true

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -101,6 +101,13 @@ jobs:
           git push origin "${{ env.NEW_VERSION }}"
 
       - name: Publish npm Package
+        if: inputs.workspaces == false
         run: |
           cd ${{ inputs.package_dir }}
           npm publish
+
+      - name: Publish npm Packages
+        if: inputs.workspaces == true
+        run: |
+          cd ${{ inputs.package_dir }}
+          npm publish --workspaces=true


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/actions/pull/9 and ensures that multiple npm packages can be published per repository.