### PR TITLE
Stage all package versions

### DIFF
--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -94,7 +94,7 @@ jobs:
           git fetch
           git checkout "${GITHUB_REF_NAME}"
           git pull origin "${GITHUB_REF_NAME}"
-          git add ${{ inputs.package_dir }}/package.json
+          git add -A
           git commit -m "${{ env.NEW_VERSION }}" --no-verify
           git tag -a "${{ env.NEW_VERSION }}" -m "${{ env.NEW_VERSION }}"
           git push origin "${GITHUB_REF_NAME}"


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/actions/pull/9 and ensures that multiple npm packages can be published per repository.