### PR TITLE
Adjust lockfile after releasing

### DIFF
--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -87,6 +87,10 @@ jobs:
           npm version ${{ inputs.version_type }} --no-git-tag-version --no-workspaces-update --workspaces
           echo "NEW_VERSION=$(npm pkg get version --workspaces=true | jq -r 'to_entries[0].value')" >> $GITHUB_ENV
 
+      - name: Adjust Lockfile
+        if: inputs.workspaces == true
+        run: bun install
+
       - name: Push New Version
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
When using a monorepo setup, the global dependency lockfile contains a list of all packages defined in the repo, so we must update the lockfile after bumping the versions.

Otherwise we get this the next time we run `bun install --force`:

![CleanShot 2025-05-22 at 15 46 10@2x](https://github.com/user-attachments/assets/baaaf414-a12e-4fc9-9103-5f62e32a33d0)
