### PR TITLE
Ensure `package_dir` is passed to `bump-version` action

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Bump Package
         uses: ronin-co/actions/.github/actions/bump-version@main
         with:
-          package_dir: './'
+          package_dir: ${{ inputs.package_dir }}
 
       - name: Get package name from package.json
         id: package-name


### PR DESCRIPTION
This change applies a small fix to the `publish-experimental` workflow so the `package_dir` input is actually passed through to the `bump-version` action.