### PR TITLE
Bump default Bun version

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -3,6 +3,11 @@ name: Publish Experimental Packages
 on:
   workflow_call:
     inputs:
+      bun_version:
+        description: 'The version of Bun to use'
+        required: false
+        default: "1.2.22"
+        type: string
       package_dir:
         description: 'Directory of the package to publish'
         required: false
@@ -33,7 +38,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.10
+          bun-version: ${{ inputs.bun_version }}
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish-manually.yml
+++ b/.github/workflows/publish-manually.yml
@@ -3,6 +3,11 @@ name: Manually Publish npm Packages
 on:
   workflow_call:
     inputs:
+      bun_version:
+        description: 'The version of Bun to use'
+        required: false
+        default: '1.2.22'
+        type: string
       version_type:
         description: 'Version type to bump the package version by.'
         required: true
@@ -57,7 +62,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.10
+          bun-version: ${{ inputs.bun_version }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -3,10 +3,10 @@ name: Update
 on:
     workflow_call:
         inputs:
-            bun-version:
-              description: Bun Version
+            bun_version:
+              description: 'The version of Bun to use'
               required: false
-              default: '1.2.10'
+              default: '1.2.22'
               type: string
         secrets:
             ORG_GH_RONIN_APP_ID:
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ inputs.bun-version }}
+          bun-version: ${{ inputs.bun_version }}
 
       # Cache the local `node_modules` directory.
       - name: Restore npm Cache

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,7 +6,7 @@ on:
       bun_version:
         description: "The version of Bun to use"
         required: false
-        default: "1.2.10"
+        default: "1.2.22"
         type: string
       package_dir:
         description: "Directory of the package to validate"


### PR DESCRIPTION
This PR upgrades the default version of Bun used by all actions to `1.2.22`. This in hopes to try and fix the [on-going issue where CI](https://github.com/ronin-co/blade/actions/runs/18031706876/job/51309396593) is installing a broken package version.